### PR TITLE
reexport angle::Deg and use $crate in rgb! macro

### DIFF
--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -67,7 +67,7 @@ impl<T: Channel, C: Color<T>> Color<T> for AlphaColor<T, C> {
 #[macro_export]
 macro_rules! rgba{
     ( $r: expr, $g: expr, $b: expr, $a: expr ) => ({
-        use $crate::{Rgba,Rgb};
+        use $crate::{Rgba, Rgb};
         Rgba{ c: Rgb{ r: $r, g: $g, b: $b }, a: $a } 
     });
     ( $to_rgb: expr, $a: expr ) => ({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use hsv::{Hsv, ToHsv};
 pub use rgb::{Rgb, Rg, ToRgb, consts};
 pub use srgb::Srgb;
 pub use ycbcr::YCbCr;
+pub use angle::Deg;
 
 #[macro_use] mod rgb;
 #[macro_use] mod alpha;

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -105,13 +105,13 @@ impl<T:Channel> Rgb<T> {
 #[macro_export]
 macro_rules! rgb{
     ( $r: expr, $g: expr, $b: expr ) => {
-        Rgb{ r: $r, g: $g, b: $b } 
+        $crate::Rgb{ r: $r, g: $g, b: $b } 
     };
     ( $rg: expr, $b: expr ) => {
-        Rgb{ r: $rg.r, g: $rg.g, b: $b } 
+        $crate::Rgb{ r: $rg.r, g: $rg.g, b: $b } 
     };
     ( $r: expr, $gb: expr ) => {
-        Rgb{ r: $r, g: $gb.r, b: $gb.g } 
+        $crate::Rgb{ r: $r, g: $gb.r, b: $gb.g } 
     };
 }
 


### PR DESCRIPTION
as discussed after merging https://github.com/bjz/color-rs/pull/30 the dependency with angle would make it necessary to import that library in any project wanting to use Hsv. 

this re-exports angle::Deg as color::Deg so using angle is no longer necessary but will also keep working.

also uses $crate in the rgb! macro so it can be used across crates